### PR TITLE
Fix bug where sample didn't initially enable wall clock display

### DIFF
--- a/AzureMediaPlayer/main-amp.js
+++ b/AzureMediaPlayer/main-amp.js
@@ -2013,6 +2013,9 @@ var setup = function () {
                 }
 
                 if(document.getElementById("selectSource").options[document.getElementById("selectSource").selectedIndex].getAttribute("wallClockTimeDisplayEnabled") == "true"){
+                    $("input[name='advanced'][value='advanced']").prop('checked', true);
+                    $("#advancedOptions").show();
+                    $("#urlHelp").hide();
                     $("input[name='wallclockdisplay'][value='enabled']").prop('checked', true);
                     showWallClockDisplaySettings();
                 }


### PR DESCRIPTION
Noticed bug where, when selecting the wall clock sample video, the advanced dropdown didn't get checked, and so the wall clock display option wasn't enabled.